### PR TITLE
Add reusable BaseModel with tests

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,23 @@
-from django.db import models
+import uuid
 
-# Create your models here.
+from django.db import models
+from django.utils import timezone
+
+
+class BaseModel(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+    def save(self, *args, **kwargs):
+        self.updated_at = timezone.now()
+        super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"{self.__class__.__name__} (id: {self.id})"
 
 
 class Tenant(models.Model):

--- a/core/tests/settings.py
+++ b/core/tests/settings.py
@@ -1,0 +1,13 @@
+SECRET_KEY = 'test-secret-key'
+INSTALLED_APPS = [
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'core',
+]
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+USE_TZ = True

--- a/core/tests/test_models.py
+++ b/core/tests/test_models.py
@@ -1,0 +1,48 @@
+import time
+import uuid
+
+import pytest
+from django.apps import apps
+from django.db import connection, models
+
+from core.models import BaseModel
+
+
+@pytest.fixture
+def sample_model(transactional_db):
+    class SampleModel(BaseModel):
+        name = models.CharField(max_length=50)
+
+        class Meta:
+            app_label = "core"
+
+    with connection.schema_editor() as schema_editor:
+        schema_editor.create_model(SampleModel)
+    yield SampleModel
+    with connection.schema_editor() as schema_editor:
+        schema_editor.delete_model(SampleModel)
+    apps.all_models["core"].pop("samplemodel", None)
+    apps.clear_cache()
+
+
+@pytest.mark.django_db
+def test_base_model_fields(sample_model):
+    obj = sample_model.objects.create(name="test")
+    assert isinstance(obj.id, uuid.UUID)
+    assert obj.created_at is not None
+    assert obj.updated_at is not None
+
+
+@pytest.mark.django_db
+def test_save_updates_updated_at(sample_model):
+    obj = sample_model.objects.create(name="test")
+    old_updated_at = obj.updated_at
+    time.sleep(0.01)
+    obj.save()
+    assert obj.updated_at > old_updated_at
+
+
+@pytest.mark.django_db
+def test_str_representation(sample_model):
+    obj = sample_model.objects.create(name="test")
+    assert str(obj) == f"SampleModel (id: {obj.id})"


### PR DESCRIPTION
## Summary
- add abstract `BaseModel` with UUID primary key and timestamp fields
- implement `save` method and string representation
- add pytest suite for `BaseModel`

## Testing
- `pre-commit run --hook-stage manual --files core/models.py core/tests/test_models.py core/tests/__init__.py core/tests/settings.py`
- `DJANGO_SETTINGS_MODULE=core.tests.settings pytest core/tests/test_models.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d0bc9ac483228b5688f97f16ba54