### PR TITLE
CI: limit black/isort/autoflake to core apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,14 @@ jobs:
         run: flake8 .
 
       - name: Format check (black)
-        run: black --check .
+        run: black --check core common tenants accounts project_root
 
       - name: Import sort check (isort)
-        run: isort --check-only .
+        run: isort --check-only core common tenants accounts project_root
 
       - name: Remove unused imports/vars (autoflake)
-        run: autoflake --check --recursive --remove-all-unused-imports --remove-unused-variables .
+        run: autoflake --check --recursive --remove-all-unused-imports --remove-unused-variables \
+             core common tenants accounts project_root
 
       - name: Load test fixture
         run: |


### PR DESCRIPTION
## Summary
- limit black, isort and autoflake checks to core, common, tenants, accounts and project_root apps

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `yamllint .github/workflows/ci.yml` *(fails: line-length and formatting errors)*

------
https://chatgpt.com/codex/tasks/task_e_689997c1d3f883229662800a49e19a3a