### PR TITLE
Add estimator service skeleton with fixtures and smoke tests

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,1 +1,4 @@
 # __init__.py
+from .money import money
+
+__all__ = ["money"]

--- a/common/money.py
+++ b/common/money.py
@@ -1,0 +1,6 @@
+from decimal import Decimal, ROUND_HALF_UP
+
+
+def money(value) -> Decimal:
+    """Quantize value to two decimal places using ROUND_HALF_UP."""
+    return Decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)

--- a/erp_system/fixtures/price_list.json
+++ b/erp_system/fixtures/price_list.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0",
+  "effective_from": "2023-01-01",
+  "effective_to": null,
+  "material_per_kg": 2.0,
+  "paint_per_m2_per_layer": 5.0,
+  "labor_per_m2": 10.0,
+  "logistics_per_m": 2.0
+}

--- a/erp_system/fixtures/quote_norms.json
+++ b/erp_system/fixtures/quote_norms.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0",
+  "effective_from": "2023-01-01",
+  "effective_to": null,
+  "default_waste_pct": 0.05,
+  "paint_systems": {
+    "Good": {"layers": [{"name": "primer"}]},
+    "Better": {"layers": [{"name": "primer"}, {"name": "topcoat"}]},
+    "Best": {"layers": [{"name": "primer"}, {"name": "midcoat"}, {"name": "topcoat"}]}
+  }
+}

--- a/prodaja/services/estimator/__init__.py
+++ b/prodaja/services/estimator/__init__.py
@@ -1,0 +1,5 @@
+"""Estimator service package."""
+
+from .engine import estimate
+
+__all__ = ["estimate"]

--- a/prodaja/services/estimator/dto.py
+++ b/prodaja/services/estimator/dto.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class LayerSpec:
+    name: str
+    dft_um: int
+    solids_pct: Optional[float] = None
+    mix_ratio: Optional[str] = None
+    recoat_window: Optional[str] = None
+    pot_life: Optional[str] = None
+
+
+@dataclass
+class PaintSystemSpec:
+    id: str
+    name: str
+    brand: str
+    layers: List[LayerSpec]
+
+
+@dataclass
+class ItemInput:
+    type: str
+    weight_kg: float = 0.0
+    area_m2: float = 0.0
+    length_m: float = 0.0
+    uom_base: str = "unit"
+    paint_system_id: Optional[str] = None
+    conditions: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class QuoteInput:
+    tenant: str
+    currency: str
+    vat_rate: Decimal
+    is_vat_registered: bool
+    risk_band: str
+    contingency_pct: Decimal
+    margin_target_pct: Decimal
+    items: List[ItemInput]
+    options: List[str]
+
+
+@dataclass
+class EstimateComponents:
+    material: Decimal
+    paint: Decimal
+    labor: Decimal
+    logistics: Decimal
+    contingency: Decimal
+    margin: Decimal
+    net_total: Decimal
+    vat_total: Decimal
+    gross_total: Decimal
+
+
+@dataclass
+class EstimateBreakdown:
+    options: Dict[str, EstimateComponents]
+    assumptions: Dict[str, Any]

--- a/prodaja/services/estimator/engine.py
+++ b/prodaja/services/estimator/engine.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Dict
+
+from common.money import money
+
+from . import labor, logistics, material, paint, pricing
+from .dto import EstimateBreakdown, EstimateComponents, ItemInput, QuoteInput
+
+# Go three levels up: estimator -> services -> prodaja -> repo root
+FIXTURES_DIR = Path(__file__).resolve().parents[3] / "erp_system" / "fixtures"
+
+
+def _load_fixture(name: str) -> Dict:
+    with open(FIXTURES_DIR / name, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def estimate(quote: QuoteInput) -> EstimateBreakdown:
+    """Estimate costs for provided quote input."""
+    price_list = _load_fixture("price_list.json")
+    norms = _load_fixture("quote_norms.json")
+
+    policy = pricing.RoundingPolicy.PER_ITEM
+
+    option_totals: Dict[str, EstimateComponents] = {}
+    for option in quote.options:
+        material_total = Decimal("0")
+        paint_total = Decimal("0")
+        labor_total = Decimal("0")
+        logistics_total = Decimal("0")
+        for item in quote.items:
+            material_total += material.calculate(item, price_list)
+            paint_total += paint.calculate(item, option, price_list, norms)
+            labor_total += labor.calculate(item, price_list)
+            logistics_total += logistics.calculate(item, price_list)
+        component_sum = pricing.sum_components(
+            [material_total, paint_total, labor_total, logistics_total], policy
+        )
+        contingency = money(component_sum * quote.contingency_pct)
+        margin_base = component_sum + contingency
+        margin = money(margin_base * quote.margin_target_pct)
+        net_total = money(component_sum + contingency + margin)
+        vat_total = money(net_total * quote.vat_rate) if quote.is_vat_registered else Decimal("0")
+        gross_total = money(net_total + vat_total)
+        option_totals[option] = EstimateComponents(
+            material=money(material_total),
+            paint=money(paint_total),
+            labor=money(labor_total),
+            logistics=money(logistics_total),
+            contingency=contingency,
+            margin=margin,
+            net_total=net_total,
+            vat_total=vat_total,
+            gross_total=gross_total,
+        )
+
+    assumptions = {
+        "waste_pct": norms.get("default_waste_pct", 0),
+        "mode": "booth",
+        "height": "<3m",
+        "norms_version": norms.get("version"),
+        "price_list_version": price_list.get("version"),
+        "rounding_policy": policy.value,
+        "risk_band": quote.risk_band,
+    }
+    return EstimateBreakdown(options=option_totals, assumptions=assumptions)

--- a/prodaja/services/estimator/labor.py
+++ b/prodaja/services/estimator/labor.py
@@ -1,0 +1,11 @@
+from decimal import Decimal
+
+from .dto import ItemInput
+from common.money import money
+
+
+def calculate(item: ItemInput, price_list: dict) -> Decimal:
+    """Calculate labor cost based on area."""
+    rate = Decimal(str(price_list.get("labor_per_m2", 0)))
+    area = Decimal(str(item.area_m2))
+    return money(area * rate)

--- a/prodaja/services/estimator/logistics.py
+++ b/prodaja/services/estimator/logistics.py
@@ -1,0 +1,11 @@
+from decimal import Decimal
+
+from .dto import ItemInput
+from common.money import money
+
+
+def calculate(item: ItemInput, price_list: dict) -> Decimal:
+    """Calculate logistics cost based on length."""
+    rate = Decimal(str(price_list.get("logistics_per_m", 0)))
+    length = Decimal(str(item.length_m))
+    return money(length * rate)

--- a/prodaja/services/estimator/material.py
+++ b/prodaja/services/estimator/material.py
@@ -1,0 +1,10 @@
+from decimal import Decimal
+
+from .dto import ItemInput
+from common.money import money
+
+
+def calculate(item: ItemInput, price_list: dict) -> Decimal:
+    """Calculate material cost for an item."""
+    rate = Decimal(str(price_list.get("material_per_kg", 0)))
+    return money(Decimal(str(item.weight_kg)) * rate)

--- a/prodaja/services/estimator/paint.py
+++ b/prodaja/services/estimator/paint.py
@@ -1,0 +1,13 @@
+from decimal import Decimal
+
+from .dto import ItemInput
+from common.money import money
+
+
+def calculate(item: ItemInput, option: str, price_list: dict, norms: dict) -> Decimal:
+    """Calculate paint cost based on area and number of layers for an option."""
+    rate = Decimal(str(price_list.get("paint_per_m2_per_layer", 0)))
+    layers = norms.get("paint_systems", {}).get(option, {}).get("layers", [])
+    layer_count = len(layers) or 1
+    area = Decimal(str(item.area_m2))
+    return money(area * rate * layer_count)

--- a/prodaja/services/estimator/pricing.py
+++ b/prodaja/services/estimator/pricing.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from enum import Enum
+from decimal import Decimal
+from typing import Sequence
+
+from common.money import money
+
+
+class RoundingPolicy(str, Enum):
+    PER_ITEM = "per_item"
+    TOTAL = "total"
+
+
+def sum_components(components: Sequence[Decimal], policy: RoundingPolicy) -> Decimal:
+    """Sum components applying rounding policy."""
+    if policy == RoundingPolicy.PER_ITEM:
+        total = sum(money(c) for c in components)
+        return money(total)
+    total = sum(components)
+    return money(total)

--- a/tests/quote/conftest.py
+++ b/tests/quote/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def seed_minimal_accounts():
+    """Override project fixture that requires database."""
+    return

--- a/tests/quote/test_estimator_examples.py
+++ b/tests/quote/test_estimator_examples.py
@@ -1,0 +1,45 @@
+from decimal import Decimal
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+from common.money import money
+
+
+def build_quote(weight, area, length):
+    item = ItemInput(type="fabrication", weight_kg=weight, area_m2=area, length_m=length)
+    return QuoteInput(
+        tenant="demo",
+        currency="EUR",
+        vat_rate=Decimal("0.25"),
+        is_vat_registered=True,
+        risk_band="A",
+        contingency_pct=Decimal("0.10"),
+        margin_target_pct=Decimal("0.20"),
+        items=[item],
+        options=["Good", "Better", "Best"],
+    )
+
+
+def test_example_expected_totals():
+    quote = build_quote(40, 20, 5)
+    result = estimate(quote)
+    good = result.options["Good"]
+    assert good.net_total == money(Decimal("514.8"))
+    assert good.gross_total == money(Decimal("643.5"))
+
+
+def test_example_scaling():
+    quote = build_quote(100, 50, 10)
+    result = estimate(quote)
+    good = result.options["Good"]
+    assert good.net_total == money(Decimal("1280.4"))
+    better = result.options["Better"]
+    best = result.options["Best"]
+    assert good.net_total < better.net_total < best.net_total
+
+
+def test_logistics_dominates_when_long_distance():
+    quote = build_quote(50, 10, 100)
+    result = estimate(quote)
+    good = result.options["Good"]
+    assert good.logistics > good.material

--- a/tests/quote/test_estimator_smoke.py
+++ b/tests/quote/test_estimator_smoke.py
@@ -1,0 +1,32 @@
+from decimal import Decimal
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+
+
+def _base_quote(weight, area, length):
+    item = ItemInput(type="fabrication", weight_kg=weight, area_m2=area, length_m=length)
+    return QuoteInput(
+        tenant="demo",
+        currency="EUR",
+        vat_rate=Decimal("0.25"),
+        is_vat_registered=True,
+        risk_band="A",
+        contingency_pct=Decimal("0.10"),
+        margin_target_pct=Decimal("0.20"),
+        items=[item],
+        options=["Good", "Better", "Best"],
+    )
+
+
+def test_estimator_returns_positive_totals():
+    result = estimate(_base_quote(100, 50, 10))
+    for opt in ["Good", "Better", "Best"]:
+        assert result.options[opt].net_total > 0
+    assert result.options["Good"].net_total < result.options["Better"].net_total < result.options["Best"].net_total
+
+
+def test_estimator_monotonic_with_quantity():
+    small = estimate(_base_quote(50, 25, 5))
+    large = estimate(_base_quote(100, 50, 10))
+    assert small.options["Good"].net_total < large.options["Good"].net_total


### PR DESCRIPTION
## Summary
- scaffold estimator service with dataclasses and cost engine
- provide global money helper and sample price list & norms fixtures
- add smoke and example tests for estimation logic

## Testing
- `pre-commit run --files common/__init__.py common/money.py erp_system/fixtures/quote_norms.json erp_system/fixtures/price_list.json prodaja/services/estimator/__init__.py prodaja/services/estimator/dto.py prodaja/services/estimator/material.py prodaja/services/estimator/paint.py prodaja/services/estimator/labor.py prodaja/services/estimator/logistics.py prodaja/services/estimator/pricing.py prodaja/services/estimator/engine.py tests/quote/test_estimator_smoke.py tests/quote/test_estimator_examples.py`
- `pytest tests/quote`


------
https://chatgpt.com/codex/tasks/task_e_68a4a003b7a88322b1e32ca613367089