### PR TITLE
Add estimator service with property-based tests

### DIFF
--- a/erp_system/fixtures/price_list.json
+++ b/erp_system/fixtures/price_list.json
@@ -1,0 +1,9 @@
+{
+  "version": "2024.01",
+  "effective_from": "2024-01-01",
+  "effective_to": null,
+  "material": 2.0,
+  "paint": 10.0,
+  "labor": 20.0,
+  "logistics": 1.0
+}

--- a/erp_system/fixtures/quote_norms.json
+++ b/erp_system/fixtures/quote_norms.json
@@ -1,0 +1,34 @@
+{
+  "version": "2024.01",
+  "effective_from": "2024-01-01",
+  "effective_to": null,
+  "waste_pct": 0.10,
+  "painting_hours_per_m2_per_layer": 0.2,
+  "condition_multipliers": {
+    "booth": 1.0,
+    "field": 1.2
+  },
+  "paint_systems": {
+    "Good": {
+      "name": "Good",
+      "layers": [
+        {"name": "primer", "dft_um": 80, "solids_pct": 60}
+      ]
+    },
+    "Better": {
+      "name": "Better",
+      "layers": [
+        {"name": "primer", "dft_um": 100, "solids_pct": 60},
+        {"name": "topcoat", "dft_um": 80, "solids_pct": 55}
+      ]
+    },
+    "Best": {
+      "name": "Best",
+      "layers": [
+        {"name": "primer", "dft_um": 120, "solids_pct": 60},
+        {"name": "midcoat", "dft_um": 100, "solids_pct": 55},
+        {"name": "topcoat", "dft_um": 80, "solids_pct": 50}
+      ]
+    }
+  }
+}

--- a/prodaja/services/estimator/dto.py
+++ b/prodaja/services/estimator/dto.py
@@ -1,0 +1,61 @@
+"""Dataclasses used by the estimator service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+
+@dataclass
+class LayerSpec:
+    name: str
+    dft_um: float
+    solids_pct: float
+    mix_ratio: str | None = None
+    recoat_window: float | None = None
+    pot_life: float | None = None
+
+
+@dataclass
+class PaintSystemSpec:
+    id: str
+    name: str
+    brand: str | None = None
+    layers: list[LayerSpec] = field(default_factory=list)
+
+
+@dataclass
+class ItemInput:
+    """Single item that needs to be estimated."""
+
+    type: str
+    uom_base: str
+    qty_base: float
+    area_m2: float = 0.0
+    weight_kg: float = 0.0
+    paint_system_id: str | None = None
+    conditions: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class QuoteInput:
+    tenant: str
+    currency: str
+    vat_rate: Decimal
+    is_vat_registered: bool
+    risk_band: str
+    contingency_pct: Decimal
+    margin_target_pct: Decimal
+    items: list[ItemInput]
+    options: list[str]
+
+
+@dataclass
+class EstimateBreakdown:
+    components: dict[str, Decimal]
+    contingency: Decimal
+    margin: Decimal
+    net_total: Decimal
+    vat_total: Decimal
+    gross_total: Decimal
+    assumptions: dict[str, object]

--- a/prodaja/services/estimator/engine.py
+++ b/prodaja/services/estimator/engine.py
@@ -1,0 +1,93 @@
+"""Estimator engine combining all cost components."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+from .dto import (
+    EstimateBreakdown,
+    LayerSpec,
+    PaintSystemSpec,
+    QuoteInput,
+)
+from .labor import compute_labor
+from .logistics import compute_logistics
+from .material import compute_material
+from .paint import compute_paint
+from .pricing import ROUNDING_POLICY, money, sum_money
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+
+
+def _load_fixture(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _load_norms() -> dict:
+    return _load_fixture(BASE_DIR / "erp_system/fixtures/quote_norms.json")
+
+
+def _load_price_list() -> dict:
+    return _load_fixture(BASE_DIR / "erp_system/fixtures/price_list.json")
+
+
+def _parse_paint_systems(norms: dict) -> dict[str, PaintSystemSpec]:
+    systems: dict[str, PaintSystemSpec] = {}
+    for sys_id, data in norms.get("paint_systems", {}).items():
+        layers = [LayerSpec(**layer) for layer in data.get("layers", [])]
+        systems[sys_id] = PaintSystemSpec(id=sys_id, name=data.get("name", sys_id), layers=layers)
+    return systems
+
+
+def estimate(quote: QuoteInput) -> dict[str, EstimateBreakdown]:
+    """Estimate costs for each option provided in ``quote``."""
+    norms = _load_norms()
+    price_list = _load_price_list()
+    systems = _parse_paint_systems(norms)
+    breakdowns: dict[str, EstimateBreakdown] = {}
+    for option in quote.options:
+        system = systems.get(option)
+        material_total = Decimal("0")
+        paint_total = Decimal("0")
+        labor_total = Decimal("0")
+        logistics_total = Decimal("0")
+        for item in quote.items:
+            material_total += compute_material(item, price_list)
+            if system:
+                paint_total += compute_paint(item, system, price_list, norms)
+                labor_total += compute_labor(item, system, price_list, norms)
+            logistics_total += compute_logistics(item, price_list)
+        components = {
+            "material": money(material_total),
+            "paint": money(paint_total),
+            "labor": money(labor_total),
+            "logistics": money(logistics_total),
+        }
+        component_sum = sum_money(components)
+        contingency = money(component_sum * quote.contingency_pct / Decimal("100"))
+        subtotal = money(component_sum + contingency)
+        margin = money(subtotal * quote.margin_target_pct / Decimal("100"))
+        net_total = money(component_sum + contingency + margin)
+        vat_total = money(net_total * quote.vat_rate)
+        gross_total = money(net_total + vat_total)
+        assumptions = {
+            "waste_pct": norms.get("waste_pct"),
+            "mode": quote.items[0].conditions.get("mode", "booth") if quote.items else None,
+            "norms_version": norms.get("version"),
+            "price_list_version": price_list.get("version"),
+            "rounding_policy": ROUNDING_POLICY,
+            "risk_band": quote.risk_band,
+        }
+        breakdowns[option] = EstimateBreakdown(
+            components=components,
+            contingency=contingency,
+            margin=margin,
+            net_total=net_total,
+            vat_total=vat_total,
+            gross_total=gross_total,
+            assumptions=assumptions,
+        )
+    return breakdowns

--- a/prodaja/services/estimator/labor.py
+++ b/prodaja/services/estimator/labor.py
@@ -1,0 +1,26 @@
+"""Labor cost estimation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput, PaintSystemSpec
+from .pricing import money
+
+
+def compute_labor(
+    item: ItemInput,
+    system: PaintSystemSpec,
+    price_list: dict,
+    norms: dict,
+) -> Decimal:
+    """Return labor cost for painting based on area and layers."""
+    rate = Decimal(str(price_list.get("labor", 0)))
+    hours_per_m2 = Decimal(str(norms.get("painting_hours_per_m2_per_layer", 0)))
+    layers = Decimal(str(len(system.layers)))
+    area = Decimal(str(item.area_m2))
+    mode = item.conditions.get("mode", "booth")
+    cond_mult = Decimal(str(norms.get("condition_multipliers", {}).get(mode, 1)))
+    hours = area * hours_per_m2 * layers * cond_mult
+    cost = hours * rate
+    return money(cost)

--- a/prodaja/services/estimator/logistics.py
+++ b/prodaja/services/estimator/logistics.py
@@ -1,0 +1,14 @@
+"""Logistics cost estimation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput
+from .pricing import money
+
+
+def compute_logistics(item: ItemInput, price_list: dict) -> Decimal:
+    rate = Decimal(str(price_list.get("logistics", 0)))
+    cost = Decimal(str(item.weight_kg)) * Decimal("0.1") * rate
+    return money(cost)

--- a/prodaja/services/estimator/material.py
+++ b/prodaja/services/estimator/material.py
@@ -1,0 +1,15 @@
+"""Material cost calculation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput
+from .pricing import money
+
+
+def compute_material(item: ItemInput, price_list: dict) -> Decimal:
+    """Very small heuristic for material costs."""
+    rate = Decimal(str(price_list.get("material", 0)))
+    cost = rate * Decimal(str(item.weight_kg))
+    return money(cost)

--- a/prodaja/services/estimator/paint.py
+++ b/prodaja/services/estimator/paint.py
@@ -1,0 +1,31 @@
+"""Paint consumption and cost."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput, PaintSystemSpec
+from .pricing import money
+
+
+def compute_paint(
+    item: ItemInput,
+    system: PaintSystemSpec,
+    price_list: dict,
+    norms: dict,
+) -> Decimal:
+    """Estimate paint cost for an item and paint system."""
+    rate = Decimal(str(price_list.get("paint", 0)))
+    total_liters = Decimal("0")
+    area = Decimal(str(item.area_m2))
+    for layer in system.layers:
+        dft = Decimal(str(layer.dft_um)) / Decimal("1000")
+        solids = Decimal(str(layer.solids_pct)) / Decimal("100")
+        if solids == 0:
+            continue
+        liters = area * dft / solids
+        total_liters += liters
+    waste_pct = Decimal(str(norms.get("waste_pct", 0)))
+    total_liters *= Decimal("1") + waste_pct
+    cost = total_liters * rate
+    return money(cost)

--- a/prodaja/services/estimator/pricing.py
+++ b/prodaja/services/estimator/pricing.py
@@ -1,0 +1,22 @@
+"""Pricing utilities for the estimator service."""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+ROUNDING_POLICY = "total"
+
+
+def money(value: float | Decimal) -> Decimal:
+    """Return a Decimal rounded to two places using ``ROUND_HALF_UP``."""
+    if not isinstance(value, Decimal):
+        value = Decimal(str(value))
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def sum_money(values: dict[str, Decimal]) -> Decimal:
+    """Sum a mapping of Decimal values using :func:`money` after each addition."""
+    total = Decimal("0")
+    for val in values.values():
+        total = money(total + val)
+    return total

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,4 @@ black>=24.0
 isort>=5.13
 flake8>=7.0
 autoflake>=2.2
+hypothesis>=6.92

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from hypothesis import settings
+
+# CI profile with fewer examples to keep the suite fast.
+settings.register_profile("ci", max_examples=150)
+settings.load_profile("ci")

--- a/tests/quote/test_estimator_examples.py
+++ b/tests/quote/test_estimator_examples.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+
+
+def make_quote():
+    return QuoteInput(
+        tenant="t1",
+        currency="EUR",
+        vat_rate=Decimal("0.25"),
+        is_vat_registered=True,
+        risk_band="Y",
+        contingency_pct=Decimal("5"),
+        margin_target_pct=Decimal("10"),
+        items=[
+            ItemInput(
+                type="fabrication",
+                uom_base="m2",
+                qty_base=50.0,
+                area_m2=50.0,
+                weight_kg=100.0,
+                conditions={"mode": "booth"},
+            )
+        ],
+        options=["Good", "Better", "Best"],
+    )
+
+
+def test_example_totals_match_expected():
+    breakdowns = estimate(make_quote())
+    assert breakdowns["Good"].net_total == Decimal("558.25")
+    assert breakdowns["Better"].net_total == Decimal("902.83")
+    assert breakdowns["Best"].net_total == Decimal("1279.74")
+    # ensure order is preserved
+    assert (
+        breakdowns["Good"].net_total < breakdowns["Better"].net_total < breakdowns["Best"].net_total
+    )

--- a/tests/quote/test_estimator_properties.py
+++ b/tests/quote/test_estimator_properties.py
@@ -1,0 +1,89 @@
+from decimal import Decimal
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+from prodaja.services.estimator.pricing import money
+
+
+def make_quote(area, mode="booth", vat_rate=Decimal("0.25")):
+    weight = area * 2
+    return QuoteInput(
+        tenant="t1",
+        currency="EUR",
+        vat_rate=vat_rate,
+        is_vat_registered=True,
+        risk_band="Y",
+        contingency_pct=Decimal("5"),
+        margin_target_pct=Decimal("10"),
+        items=[
+            ItemInput(
+                type="fabrication",
+                uom_base="m2",
+                qty_base=area,
+                area_m2=area,
+                weight_kg=weight,
+                conditions={"mode": mode},
+            )
+        ],
+        options=["Good", "Better", "Best"],
+    )
+
+
+@given(st.floats(min_value=0.1, max_value=100))
+def test_non_negative(area):
+    res = estimate(make_quote(area))["Good"]
+    for val in res.components.values():
+        assert val >= 0
+    assert res.net_total >= 0
+    assert res.vat_total >= 0
+    assert res.gross_total >= 0
+
+
+@given(st.floats(min_value=1, max_value=50), st.floats(min_value=1, max_value=50))
+def test_monotonic(area1, area2):
+    assume(area2 > area1)
+    n1 = estimate(make_quote(area1))["Good"].net_total
+    n2 = estimate(make_quote(area2))["Good"].net_total
+    assert n2 >= n1
+
+
+@given(st.floats(min_value=1, max_value=40), st.floats(min_value=1, max_value=40))
+def test_additivity(a1, a2):
+    res1 = estimate(make_quote(a1))["Good"].net_total
+    res2 = estimate(make_quote(a2))["Good"].net_total
+    combined = estimate(make_quote(a1 + a2))["Good"].net_total
+    assert abs((res1 + res2) - combined) <= Decimal("1.00")
+
+
+@given(st.floats(min_value=1, max_value=100))
+def test_dft_increases_paint(area):
+    res = estimate(make_quote(area))
+    assert res["Better"].components["paint"] >= res["Good"].components["paint"]
+    assert res["Best"].components["paint"] >= res["Better"].components["paint"]
+
+
+@given(st.floats(min_value=1, max_value=100))
+def test_conditions_field_more_expensive(area):
+    booth = estimate(make_quote(area, mode="booth"))["Good"].components["labor"]
+    field = estimate(make_quote(area, mode="field"))["Good"].components["labor"]
+    assert field >= booth
+
+
+@given(st.floats(min_value=1, max_value=100), st.floats(min_value=0.05, max_value=0.30))
+def test_vat_consistency(area, vat):
+    vat_rate = Decimal(str(vat))
+    res = estimate(make_quote(area, vat_rate=vat_rate))["Good"]
+    expected_vat = money(res.net_total * vat_rate)
+    assert res.vat_total == expected_vat
+    assert res.gross_total == res.net_total + res.vat_total
+
+
+@given(st.floats(min_value=1, max_value=100))
+def test_rounding_identity(area):
+    res = estimate(make_quote(area))["Good"]
+    comp_sum = sum(res.components.values())
+    assert comp_sum + res.contingency + res.margin == res.net_total
+    assert res.net_total + res.vat_total == res.gross_total

--- a/tests/quote/test_estimator_smoke.py
+++ b/tests/quote/test_estimator_smoke.py
@@ -1,0 +1,43 @@
+from decimal import Decimal
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+
+
+def make_quote(area=50.0, weight=100.0, mode="booth"):
+    return QuoteInput(
+        tenant="t1",
+        currency="EUR",
+        vat_rate=Decimal("0.25"),
+        is_vat_registered=True,
+        risk_band="Y",
+        contingency_pct=Decimal("5"),
+        margin_target_pct=Decimal("10"),
+        items=[
+            ItemInput(
+                type="fabrication",
+                uom_base="m2",
+                qty_base=area,
+                area_m2=area,
+                weight_kg=weight,
+                conditions={"mode": mode},
+            )
+        ],
+        options=["Good", "Better", "Best"],
+    )
+
+
+def test_smoke_three_options_positive_totals():
+    quote = make_quote()
+    breakdowns = estimate(quote)
+    assert set(breakdowns.keys()) == {"Good", "Better", "Best"}
+    for bd in breakdowns.values():
+        assert bd.net_total > 0
+        assert bd.vat_total > 0
+        assert bd.gross_total > 0
+
+
+def test_monotonic_increase_with_area():
+    small = estimate(make_quote(area=10.0))["Good"].net_total
+    large = estimate(make_quote(area=20.0))["Good"].net_total
+    assert large > small


### PR DESCRIPTION
## Summary
- add estimator service with cost calculation engine and money rounding helper
- provide quote norms and price list fixtures for Good/Better/Best paint systems
- add smoke, example and property-based tests for estimator using Hypothesis

## Testing
- `pre-commit run --files prodaja/services/estimator/__init__.py prodaja/services/estimator/pricing.py prodaja/services/estimator/dto.py prodaja/services/estimator/material.py prodaja/services/estimator/paint.py prodaja/services/estimator/labor.py prodaja/services/estimator/logistics.py prodaja/services/estimator/engine.py erp_system/fixtures/quote_norms.json erp_system/fixtures/price_list.json tests/conftest.py tests/quote/test_estimator_smoke.py tests/quote/test_estimator_examples.py tests/quote/test_estimator_properties.py requirements.txt`
- `pytest tests/quote -q`

------
https://chatgpt.com/codex/tasks/task_e_68a716ed7c288322b3921fce98e06d95