### PR TITLE
Add quote models and API endpoints

### DIFF
--- a/erp_system/fixtures/price_list.json
+++ b/erp_system/fixtures/price_list.json
@@ -1,0 +1,9 @@
+{
+  "version": "2024.01",
+  "effective_from": "2024-01-01",
+  "effective_to": null,
+  "material": 2.0,
+  "paint": 10.0,
+  "labor": 20.0,
+  "logistics": 1.0
+}

--- a/erp_system/fixtures/quote_norms.json
+++ b/erp_system/fixtures/quote_norms.json
@@ -1,0 +1,34 @@
+{
+  "version": "2024.01",
+  "effective_from": "2024-01-01",
+  "effective_to": null,
+  "waste_pct": 0.10,
+  "painting_hours_per_m2_per_layer": 0.2,
+  "condition_multipliers": {
+    "booth": 1.0,
+    "field": 1.2
+  },
+  "paint_systems": {
+    "Good": {
+      "name": "Good",
+      "layers": [
+        {"name": "primer", "dft_um": 80, "solids_pct": 60}
+      ]
+    },
+    "Better": {
+      "name": "Better",
+      "layers": [
+        {"name": "primer", "dft_um": 100, "solids_pct": 60},
+        {"name": "topcoat", "dft_um": 80, "solids_pct": 55}
+      ]
+    },
+    "Best": {
+      "name": "Best",
+      "layers": [
+        {"name": "primer", "dft_um": 120, "solids_pct": 60},
+        {"name": "midcoat", "dft_um": 100, "solids_pct": 55},
+        {"name": "topcoat", "dft_um": 80, "solids_pct": 50}
+      ]
+    }
+  }
+}

--- a/erp_system/settings/base.py
+++ b/erp_system/settings/base.py
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "core.middleware.tenant_middleware.TenantMiddleware",
 ]
 
 ROOT_URLCONF = "erp_system.urls"

--- a/erp_system/urls.py
+++ b/erp_system/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/", include("prodaja.api_urls")),
 ]

--- a/prodaja/api.py
+++ b/prodaja/api.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from decimal import Decimal
+from typing import Any
+
+from django.conf import settings
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from tenants.models import Tenant
+
+from .models.quote import EstimSnapshot, Quote
+from .services.estimator.dto import ItemInput, QuoteInput
+from .services.estimator.engine import estimate
+
+_IDEMPOTENCY_CACHE: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+
+
+def _cache_key(request, extra: str = "") -> tuple[str, str, str, str]:
+    return (
+        request.tenant,
+        request.path,
+        request.META.get("HTTP_IDEMPOTENCY_KEY", ""),
+        extra,
+    )
+
+
+def _get_tenant(request) -> Tenant:
+    return Tenant.objects.get(name=request.tenant)
+
+
+def _parse_quote_input(data: dict) -> QuoteInput:
+    items = [ItemInput(**item) for item in data.get("items", [])]
+    return QuoteInput(
+        tenant=data["tenant"],
+        currency=data["currency"],
+        vat_rate=Decimal(str(data["vat_rate"])),
+        is_vat_registered=data["is_vat_registered"],
+        risk_band=data["risk_band"],
+        contingency_pct=Decimal(str(data["contingency_pct"])),
+        margin_target_pct=Decimal(str(data["margin_target_pct"])),
+        items=items,
+        options=data["options"],
+    )
+
+
+def _serialize_breakdowns(breakdowns: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    out: dict[str, Any] = {}
+    assumptions: dict[str, Any] = {}
+    for opt, bd in breakdowns.items():
+        out[opt] = {
+            **{k: float(v) for k, v in bd.components.items()},
+            "contingency": float(bd.contingency),
+            "margin": float(bd.margin),
+            "net_total": float(bd.net_total),
+            "vat_total": float(bd.vat_total),
+            "gross_total": float(bd.gross_total),
+        }
+        assumptions = bd.assumptions
+    return out, assumptions
+
+
+def _snapshot_dict(snapshot: EstimSnapshot) -> dict[str, Any]:
+    return {
+        "input": snapshot.input_data,
+        "breakdown": snapshot.breakdown,
+        "norms_version": snapshot.norms_version,
+        "price_list_version": snapshot.price_list_version,
+        "rounding_policy": snapshot.rounding_policy,
+    }
+
+
+def _compute_hash(snapshot_data: dict) -> str:
+    payload = json.dumps(snapshot_data, sort_keys=True)
+    return hmac.new(settings.SECRET_KEY.encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+
+class EstimateView(APIView):
+    def post(self, request):
+        if "HTTP_IDEMPOTENCY_KEY" not in request.META:
+            return Response({"detail": "Missing Idempotency-Key"}, status=400)
+        key = _cache_key(request)
+        if key in _IDEMPOTENCY_CACHE:
+            return Response(_IDEMPOTENCY_CACHE[key])
+        quote_input = _parse_quote_input(request.data)
+        breakdowns = estimate(quote_input)
+        serialized, assumptions = _serialize_breakdowns(breakdowns)
+        resp = {"options": serialized, "assumptions": assumptions}
+        _IDEMPOTENCY_CACHE[key] = resp
+        return Response(resp)
+
+
+class QuoteCreateView(APIView):
+    def post(self, request):
+        tenant_obj = _get_tenant(request)
+        quote_input = _parse_quote_input(request.data)
+        breakdowns = estimate(quote_input)
+        serialized, assumptions = _serialize_breakdowns(breakdowns)
+        quote = Quote.objects.create(
+            tenant=tenant_obj,
+            number=request.data.get("number"),
+            valid_until=request.data.get("valid_until"),
+            currency=quote_input.currency,
+            vat_rate=quote_input.vat_rate,
+            is_vat_registered=quote_input.is_vat_registered,
+            customer_name=request.data.get("customer_name", ""),
+            risk_band=quote_input.risk_band,
+            contingency_pct=quote_input.contingency_pct,
+            margin_target_pct=quote_input.margin_target_pct,
+        )
+        EstimSnapshot.objects.create(
+            tenant=tenant_obj,
+            quote=quote,
+            norms_version=assumptions.get("norms_version", ""),
+            price_list_version=assumptions.get("price_list_version", ""),
+            rounding_policy=assumptions.get("rounding_policy", ""),
+            input_data=request.data,
+            breakdown=serialized,
+            version="1",
+        )
+        return Response({"id": quote.id, "status": quote.status}, status=status.HTTP_201_CREATED)
+
+
+class QuoteDetailView(APIView):
+    def get(self, request, pk: int):
+        tenant_obj = _get_tenant(request)
+        quote = get_object_or_404(Quote, pk=pk, tenant=tenant_obj)
+        snapshot = quote.snapshots.order_by("-created_at").first()
+        data = {
+            "id": quote.id,
+            "number": quote.number,
+            "status": quote.status,
+            "snapshot": _snapshot_dict(snapshot) if snapshot else None,
+        }
+        return Response(data)
+
+
+class QuoteSendView(APIView):
+    def post(self, request, pk: int):
+        tenant_obj = _get_tenant(request)
+        quote = get_object_or_404(Quote, pk=pk, tenant=tenant_obj)
+        quote.status = "sent"
+        quote.save()
+        return Response({"status": quote.status})
+
+
+class QuoteAcceptView(APIView):
+    def post(self, request, pk: int):
+        if "HTTP_IDEMPOTENCY_KEY" not in request.META:
+            return Response({"detail": "Missing Idempotency-Key"}, status=400)
+        key = _cache_key(request, extra=str(pk))
+        if key in _IDEMPOTENCY_CACHE:
+            return Response(_IDEMPOTENCY_CACHE[key])
+        tenant_obj = _get_tenant(request)
+        quote = get_object_or_404(Quote, pk=pk, tenant=tenant_obj)
+        snapshot = quote.snapshots.order_by("-created_at").first()
+        if not snapshot:
+            return Response({"detail": "No snapshot"}, status=400)
+        snapshot_data = _snapshot_dict(snapshot)
+        expected = _compute_hash(snapshot_data)
+        provided = request.data.get("acceptance_hash")
+        if expected != provided:
+            return Response({"detail": "Invalid acceptance hash"}, status=400)
+        if quote.status != "accepted":
+            quote.status = "accepted"
+            quote.accepted_at = timezone.now()
+            quote.acceptance_hash = expected
+            quote.save()
+        resp = {
+            "status": quote.status,
+            "accepted_at": quote.accepted_at.isoformat() if quote.accepted_at else None,
+        }
+        _IDEMPOTENCY_CACHE[key] = resp
+        return Response(resp)

--- a/prodaja/api_urls.py
+++ b/prodaja/api_urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+
+from .api import (
+    EstimateView,
+    QuoteAcceptView,
+    QuoteCreateView,
+    QuoteDetailView,
+    QuoteSendView,
+)
+
+urlpatterns = [
+    path("quotes/estimate", EstimateView.as_view()),
+    path("quotes", QuoteCreateView.as_view()),
+    path("quotes/<int:pk>", QuoteDetailView.as_view()),
+    path("quotes/<int:pk>/send", QuoteSendView.as_view()),
+    path("quotes/<int:pk>/accept", QuoteAcceptView.as_view()),
+]

--- a/prodaja/migrations/0014_quote_models.py
+++ b/prodaja/migrations/0014_quote_models.py
@@ -1,0 +1,336 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tenants", "0005_tenant_vat_fiscal_and_settings_accounts"),
+        ("prodaja", "0013_remove_projectservicetype_tenant_id_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Quote",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created at")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Updated at")),
+                ("is_active", models.BooleanField(default=True, verbose_name="Active")),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quote_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quote_updated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("number", models.CharField(max_length=64)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("draft", "draft"),
+                            ("sent", "sent"),
+                            ("accepted", "accepted"),
+                            ("expired", "expired"),
+                        ],
+                        default="draft",
+                        max_length=20,
+                    ),
+                ),
+                ("valid_until", models.DateField(blank=True, null=True)),
+                ("currency", models.CharField(max_length=3)),
+                ("vat_rate", models.DecimalField(decimal_places=2, max_digits=5)),
+                ("is_vat_registered", models.BooleanField(default=True)),
+                ("customer_name", models.CharField(max_length=255)),
+                ("customer_vat_id", models.CharField(blank=True, max_length=64, null=True)),
+                ("site_address", models.CharField(blank=True, max_length=255, null=True)),
+                ("contact_email", models.EmailField(blank=True, max_length=254, null=True)),
+                ("contact_phone", models.CharField(blank=True, max_length=64, null=True)),
+                ("lead_source", models.CharField(blank=True, max_length=64, null=True)),
+                ("risk_band", models.CharField(max_length=10)),
+                ("contingency_pct", models.DecimalField(decimal_places=2, default=0, max_digits=5)),
+                (
+                    "margin_target_pct",
+                    models.DecimalField(decimal_places=2, default=0, max_digits=5),
+                ),
+                ("accepted_at", models.DateTimeField(blank=True, null=True)),
+                ("accepted_by", models.CharField(blank=True, max_length=255, null=True)),
+                ("acceptance_hash", models.CharField(blank=True, max_length=128, null=True)),
+                ("warranty", models.CharField(blank=True, max_length=255, null=True)),
+                ("payment_terms", models.CharField(blank=True, max_length=255, null=True)),
+                ("revision", models.PositiveIntegerField(default=1)),
+                ("attachments", models.JSONField(blank=True, default=list)),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tenants.tenant",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+        migrations.CreateModel(
+            name="QuoteItem",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created at")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Updated at")),
+                ("is_active", models.BooleanField(default=True, verbose_name="Active")),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quoteitem_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quoteitem_updated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("type", models.CharField(max_length=32)),
+                ("description", models.TextField(blank=True)),
+                ("uom_base", models.CharField(max_length=16)),
+                ("qty_base", models.DecimalField(decimal_places=2, max_digits=10)),
+                ("item_ref", models.CharField(blank=True, max_length=64, null=True)),
+                ("paint_system_id", models.CharField(blank=True, max_length=64, null=True)),
+                (
+                    "quote",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="items",
+                        to="prodaja.quote",
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tenants.tenant",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+        migrations.CreateModel(
+            name="QuoteOption",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created at")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Updated at")),
+                ("is_active", models.BooleanField(default=True, verbose_name="Active")),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quoteoption_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quoteoption_updated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("name", models.CharField(max_length=32)),
+                (
+                    "quote",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="options",
+                        to="prodaja.quote",
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tenants.tenant",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+        migrations.CreateModel(
+            name="EstimSnapshot",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created at")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Updated at")),
+                ("is_active", models.BooleanField(default=True, verbose_name="Active")),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="estimsnapshot_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="estimsnapshot_updated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("norms_version", models.CharField(max_length=32)),
+                ("price_list_version", models.CharField(max_length=32)),
+                ("rounding_policy", models.CharField(max_length=16)),
+                ("input_data", models.JSONField()),
+                ("breakdown", models.JSONField()),
+                ("version", models.CharField(max_length=32)),
+                (
+                    "option",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="snapshots",
+                        to="prodaja.quoteoption",
+                    ),
+                ),
+                (
+                    "quote",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="snapshots",
+                        to="prodaja.quote",
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tenants.tenant",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+        migrations.CreateModel(
+            name="QuoteRevision",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created at")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Updated at")),
+                ("is_active", models.BooleanField(default=True, verbose_name="Active")),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quoterevision_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="quoterevision_updated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                ("reason_code", models.CharField(max_length=32)),
+                ("delta", models.JSONField(blank=True, default=dict)),
+                (
+                    "new_snapshot",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="new_revisions",
+                        to="prodaja.estimsnapshot",
+                    ),
+                ),
+                (
+                    "parent",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="revisions",
+                        to="prodaja.quote",
+                    ),
+                ),
+                (
+                    "prev_snapshot",
+                    models.ForeignKey(
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="prev_revisions",
+                        to="prodaja.estimsnapshot",
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="tenants.tenant",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+    ]

--- a/prodaja/models.py
+++ b/prodaja/models.py
@@ -6,3 +6,4 @@ Remove once all imports updated to use prodaja.models.* directly from the packag
 """
 
 from .models.main import *  # noqa: F401,F403
+from .models.quote import *  # noqa: F401,F403

--- a/prodaja/models/__init__.py
+++ b/prodaja/models/__init__.py
@@ -1,1 +1,2 @@
 from .main import *  # noqa: F401,F403 re-export all defined model classes
+from .quote import *  # noqa: F401,F403

--- a/prodaja/models/quote.py
+++ b/prodaja/models/quote.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.db import models
+
+from common.models import BaseModel
+from tenants.models import Tenant
+
+
+class Quote(BaseModel):
+    STATUS_CHOICES = [
+        ("draft", "draft"),
+        ("sent", "sent"),
+        ("accepted", "accepted"),
+        ("expired", "expired"),
+    ]
+
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
+    number = models.CharField(max_length=64)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="draft")
+    valid_until = models.DateField(null=True, blank=True)
+    currency = models.CharField(max_length=3)
+    vat_rate = models.DecimalField(max_digits=5, decimal_places=2)
+    is_vat_registered = models.BooleanField(default=True)
+    customer_name = models.CharField(max_length=255)
+    customer_vat_id = models.CharField(max_length=64, blank=True, null=True)
+    site_address = models.CharField(max_length=255, blank=True, null=True)
+    contact_email = models.EmailField(blank=True, null=True)
+    contact_phone = models.CharField(max_length=64, blank=True, null=True)
+    lead_source = models.CharField(max_length=64, blank=True, null=True)
+    risk_band = models.CharField(max_length=10)
+    contingency_pct = models.DecimalField(max_digits=5, decimal_places=2, default=Decimal("0"))
+    margin_target_pct = models.DecimalField(max_digits=5, decimal_places=2, default=Decimal("0"))
+    accepted_at = models.DateTimeField(null=True, blank=True)
+    accepted_by = models.CharField(max_length=255, blank=True, null=True)
+    acceptance_hash = models.CharField(max_length=128, blank=True, null=True)
+    warranty = models.CharField(max_length=255, blank=True, null=True)
+    payment_terms = models.CharField(max_length=255, blank=True, null=True)
+    revision = models.PositiveIntegerField(default=1)
+    attachments = models.JSONField(blank=True, default=list)
+
+
+class QuoteItem(BaseModel):
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
+    quote = models.ForeignKey(Quote, related_name="items", on_delete=models.CASCADE)
+    type = models.CharField(max_length=32)
+    description = models.TextField(blank=True)
+    uom_base = models.CharField(max_length=16)
+    qty_base = models.DecimalField(max_digits=10, decimal_places=2)
+    item_ref = models.CharField(max_length=64, blank=True, null=True)
+    paint_system_id = models.CharField(max_length=64, blank=True, null=True)
+
+
+class QuoteOption(BaseModel):
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
+    quote = models.ForeignKey(Quote, related_name="options", on_delete=models.CASCADE)
+    name = models.CharField(max_length=32)
+
+
+class EstimSnapshot(BaseModel):
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
+    quote = models.ForeignKey(Quote, related_name="snapshots", on_delete=models.CASCADE)
+    option = models.ForeignKey(
+        QuoteOption, related_name="snapshots", on_delete=models.CASCADE, null=True, blank=True
+    )
+    norms_version = models.CharField(max_length=32)
+    price_list_version = models.CharField(max_length=32)
+    rounding_policy = models.CharField(max_length=16)
+    input_data = models.JSONField()
+    breakdown = models.JSONField()
+    version = models.CharField(max_length=32)
+
+
+class QuoteRevision(BaseModel):
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
+    parent = models.ForeignKey(Quote, related_name="revisions", on_delete=models.CASCADE)
+    prev_snapshot = models.ForeignKey(
+        EstimSnapshot, related_name="prev_revisions", on_delete=models.SET_NULL, null=True
+    )
+    new_snapshot = models.ForeignKey(
+        EstimSnapshot, related_name="new_revisions", on_delete=models.SET_NULL, null=True
+    )
+    reason_code = models.CharField(max_length=32)
+    delta = models.JSONField(blank=True, default=dict)

--- a/prodaja/services/estimator/dto.py
+++ b/prodaja/services/estimator/dto.py
@@ -1,0 +1,61 @@
+"""Dataclasses used by the estimator service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+
+@dataclass
+class LayerSpec:
+    name: str
+    dft_um: float
+    solids_pct: float
+    mix_ratio: str | None = None
+    recoat_window: float | None = None
+    pot_life: float | None = None
+
+
+@dataclass
+class PaintSystemSpec:
+    id: str
+    name: str
+    brand: str | None = None
+    layers: list[LayerSpec] = field(default_factory=list)
+
+
+@dataclass
+class ItemInput:
+    """Single item that needs to be estimated."""
+
+    type: str
+    uom_base: str
+    qty_base: float
+    area_m2: float = 0.0
+    weight_kg: float = 0.0
+    paint_system_id: str | None = None
+    conditions: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class QuoteInput:
+    tenant: str
+    currency: str
+    vat_rate: Decimal
+    is_vat_registered: bool
+    risk_band: str
+    contingency_pct: Decimal
+    margin_target_pct: Decimal
+    items: list[ItemInput]
+    options: list[str]
+
+
+@dataclass
+class EstimateBreakdown:
+    components: dict[str, Decimal]
+    contingency: Decimal
+    margin: Decimal
+    net_total: Decimal
+    vat_total: Decimal
+    gross_total: Decimal
+    assumptions: dict[str, object]

--- a/prodaja/services/estimator/engine.py
+++ b/prodaja/services/estimator/engine.py
@@ -1,0 +1,93 @@
+"""Estimator engine combining all cost components."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+from .dto import (
+    EstimateBreakdown,
+    LayerSpec,
+    PaintSystemSpec,
+    QuoteInput,
+)
+from .labor import compute_labor
+from .logistics import compute_logistics
+from .material import compute_material
+from .paint import compute_paint
+from .pricing import ROUNDING_POLICY, money, sum_money
+
+BASE_DIR = Path(__file__).resolve().parents[3]
+
+
+def _load_fixture(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _load_norms() -> dict:
+    return _load_fixture(BASE_DIR / "erp_system/fixtures/quote_norms.json")
+
+
+def _load_price_list() -> dict:
+    return _load_fixture(BASE_DIR / "erp_system/fixtures/price_list.json")
+
+
+def _parse_paint_systems(norms: dict) -> dict[str, PaintSystemSpec]:
+    systems: dict[str, PaintSystemSpec] = {}
+    for sys_id, data in norms.get("paint_systems", {}).items():
+        layers = [LayerSpec(**layer) for layer in data.get("layers", [])]
+        systems[sys_id] = PaintSystemSpec(id=sys_id, name=data.get("name", sys_id), layers=layers)
+    return systems
+
+
+def estimate(quote: QuoteInput) -> dict[str, EstimateBreakdown]:
+    """Estimate costs for each option provided in ``quote``."""
+    norms = _load_norms()
+    price_list = _load_price_list()
+    systems = _parse_paint_systems(norms)
+    breakdowns: dict[str, EstimateBreakdown] = {}
+    for option in quote.options:
+        system = systems.get(option)
+        material_total = Decimal("0")
+        paint_total = Decimal("0")
+        labor_total = Decimal("0")
+        logistics_total = Decimal("0")
+        for item in quote.items:
+            material_total += compute_material(item, price_list)
+            if system:
+                paint_total += compute_paint(item, system, price_list, norms)
+                labor_total += compute_labor(item, system, price_list, norms)
+            logistics_total += compute_logistics(item, price_list)
+        components = {
+            "material": money(material_total),
+            "paint": money(paint_total),
+            "labor": money(labor_total),
+            "logistics": money(logistics_total),
+        }
+        component_sum = sum_money(components)
+        contingency = money(component_sum * quote.contingency_pct / Decimal("100"))
+        subtotal = money(component_sum + contingency)
+        margin = money(subtotal * quote.margin_target_pct / Decimal("100"))
+        net_total = money(component_sum + contingency + margin)
+        vat_total = money(net_total * quote.vat_rate)
+        gross_total = money(net_total + vat_total)
+        assumptions = {
+            "waste_pct": norms.get("waste_pct"),
+            "mode": quote.items[0].conditions.get("mode", "booth") if quote.items else None,
+            "norms_version": norms.get("version"),
+            "price_list_version": price_list.get("version"),
+            "rounding_policy": ROUNDING_POLICY,
+            "risk_band": quote.risk_band,
+        }
+        breakdowns[option] = EstimateBreakdown(
+            components=components,
+            contingency=contingency,
+            margin=margin,
+            net_total=net_total,
+            vat_total=vat_total,
+            gross_total=gross_total,
+            assumptions=assumptions,
+        )
+    return breakdowns

--- a/prodaja/services/estimator/labor.py
+++ b/prodaja/services/estimator/labor.py
@@ -1,0 +1,26 @@
+"""Labor cost estimation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput, PaintSystemSpec
+from .pricing import money
+
+
+def compute_labor(
+    item: ItemInput,
+    system: PaintSystemSpec,
+    price_list: dict,
+    norms: dict,
+) -> Decimal:
+    """Return labor cost for painting based on area and layers."""
+    rate = Decimal(str(price_list.get("labor", 0)))
+    hours_per_m2 = Decimal(str(norms.get("painting_hours_per_m2_per_layer", 0)))
+    layers = Decimal(str(len(system.layers)))
+    area = Decimal(str(item.area_m2))
+    mode = item.conditions.get("mode", "booth")
+    cond_mult = Decimal(str(norms.get("condition_multipliers", {}).get(mode, 1)))
+    hours = area * hours_per_m2 * layers * cond_mult
+    cost = hours * rate
+    return money(cost)

--- a/prodaja/services/estimator/logistics.py
+++ b/prodaja/services/estimator/logistics.py
@@ -1,0 +1,14 @@
+"""Logistics cost estimation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput
+from .pricing import money
+
+
+def compute_logistics(item: ItemInput, price_list: dict) -> Decimal:
+    rate = Decimal(str(price_list.get("logistics", 0)))
+    cost = Decimal(str(item.weight_kg)) * Decimal("0.1") * rate
+    return money(cost)

--- a/prodaja/services/estimator/material.py
+++ b/prodaja/services/estimator/material.py
@@ -1,0 +1,15 @@
+"""Material cost calculation."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput
+from .pricing import money
+
+
+def compute_material(item: ItemInput, price_list: dict) -> Decimal:
+    """Very small heuristic for material costs."""
+    rate = Decimal(str(price_list.get("material", 0)))
+    cost = rate * Decimal(str(item.weight_kg))
+    return money(cost)

--- a/prodaja/services/estimator/paint.py
+++ b/prodaja/services/estimator/paint.py
@@ -1,0 +1,31 @@
+"""Paint consumption and cost."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from .dto import ItemInput, PaintSystemSpec
+from .pricing import money
+
+
+def compute_paint(
+    item: ItemInput,
+    system: PaintSystemSpec,
+    price_list: dict,
+    norms: dict,
+) -> Decimal:
+    """Estimate paint cost for an item and paint system."""
+    rate = Decimal(str(price_list.get("paint", 0)))
+    total_liters = Decimal("0")
+    area = Decimal(str(item.area_m2))
+    for layer in system.layers:
+        dft = Decimal(str(layer.dft_um)) / Decimal("1000")
+        solids = Decimal(str(layer.solids_pct)) / Decimal("100")
+        if solids == 0:
+            continue
+        liters = area * dft / solids
+        total_liters += liters
+    waste_pct = Decimal(str(norms.get("waste_pct", 0)))
+    total_liters *= Decimal("1") + waste_pct
+    cost = total_liters * rate
+    return money(cost)

--- a/prodaja/services/estimator/pricing.py
+++ b/prodaja/services/estimator/pricing.py
@@ -1,0 +1,22 @@
+"""Pricing utilities for the estimator service."""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+ROUNDING_POLICY = "total"
+
+
+def money(value: float | Decimal) -> Decimal:
+    """Return a Decimal rounded to two places using ``ROUND_HALF_UP``."""
+    if not isinstance(value, Decimal):
+        value = Decimal(str(value))
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def sum_money(values: dict[str, Decimal]) -> Decimal:
+    """Sum a mapping of Decimal values using :func:`money` after each addition."""
+    total = Decimal("0")
+    for val in values.values():
+        total = money(total + val)
+    return total

--- a/prodaja/services/quote_pdf.py
+++ b/prodaja/services/quote_pdf.py
@@ -1,0 +1,48 @@
+import hashlib
+import json
+from typing import Any
+
+from django.template.loader import render_to_string
+from weasyprint import HTML
+
+from prodaja.models.quote import EstimSnapshot, Quote, QuoteOption
+
+
+def _get_snapshot(quote: Quote, option: QuoteOption) -> EstimSnapshot:
+    return EstimSnapshot.objects.filter(quote=quote, option=option).order_by("-created_at").first()
+
+
+def compute_snapshot_hash(snapshot: EstimSnapshot) -> str:
+    payload = {
+        "rounding_policy": snapshot.rounding_policy,
+        "norms_version": snapshot.norms_version,
+        "price_list_version": snapshot.price_list_version,
+        "breakdown": snapshot.breakdown,
+    }
+    serialized = json.dumps(payload, sort_keys=True)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def _render(template: str, quote_id: int, option_name: str) -> bytes:
+    quote = Quote.objects.get(id=quote_id)
+    option = quote.options.get(name=option_name)
+    snapshot = _get_snapshot(quote, option)
+    if not snapshot:
+        raise ValueError("Snapshot not found")
+    snapshot_hash = compute_snapshot_hash(snapshot)
+    context: dict[str, Any] = {
+        "quote": quote,
+        "option": option,
+        "breakdown": snapshot.breakdown,
+        "snapshot_hash": snapshot_hash,
+    }
+    html = render_to_string(template, context)
+    return HTML(string=html).write_pdf()
+
+
+def render_client_pdf(quote_id: int, option_name: str) -> bytes:
+    return _render("quotes/client.html", quote_id, option_name)
+
+
+def render_internal_pdf(quote_id: int, option_name: str) -> bytes:
+    return _render("quotes/internal.html", quote_id, option_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,4 @@ black>=24.0
 isort>=5.13
 flake8>=7.0
 autoflake>=2.2
+hypothesis>=6.92

--- a/templates/quotes/client.html
+++ b/templates/quotes/client.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Quote {{ quote.number }} - {{ option.name }}</h1>
+<p>Valid until: {{ quote.valid_until }}</p>
+<table>
+  <tr><th>Component</th><th>Amount</th></tr>
+  {% for name, amount in breakdown.components.items %}
+  <tr><td>{{ name }}</td><td>{{ amount }}</td></tr>
+  {% endfor %}
+  <tr><td>Net Total</td><td>{{ breakdown.net_total }}</td></tr>
+  <tr><td>VAT Total</td><td>{{ breakdown.vat_total }}</td></tr>
+  <tr><td>Gross Total</td><td>{{ breakdown.gross_total }}</td></tr>
+</table>
+<footer>Snapshot: {{ snapshot_hash }}</footer>
+</body>
+</html>

--- a/templates/quotes/internal.html
+++ b/templates/quotes/internal.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Quote {{ quote.number }} - {{ option.name }} (Internal)</h1>
+<p>Valid until: {{ quote.valid_until }}</p>
+<pre>{{ breakdown }}</pre>
+<footer>Snapshot: {{ snapshot_hash }}</footer>
+</body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from hypothesis import settings
+
+# CI profile with fewer examples to keep the suite fast.
+settings.register_profile("ci", max_examples=150)
+settings.load_profile("ci")

--- a/tests/quote/test_api_estimate.py
+++ b/tests/quote/test_api_estimate.py
@@ -1,0 +1,50 @@
+import pytest
+from rest_framework.test import APIClient
+
+from tenants.models import Tenant
+
+
+@pytest.mark.django_db
+def test_estimate_endpoint_idempotent():
+    Tenant.objects.create(name="t1", domain="t1")
+    client = APIClient()
+    data = {
+        "tenant": "t1",
+        "currency": "EUR",
+        "vat_rate": "0.25",
+        "is_vat_registered": True,
+        "risk_band": "Y",
+        "contingency_pct": "5",
+        "margin_target_pct": "10",
+        "items": [
+            {
+                "type": "fabrication",
+                "uom_base": "m2",
+                "qty_base": 10.0,
+                "area_m2": 10.0,
+                "weight_kg": 20.0,
+                "conditions": {"mode": "booth"},
+            }
+        ],
+        "options": ["Good", "Better", "Best"],
+    }
+    key = "abc123"
+    resp1 = client.post(
+        "/api/quotes/estimate",
+        data,
+        format="json",
+        HTTP_X_TENANT="t1",
+        HTTP_IDEMPOTENCY_KEY=key,
+    )
+    assert resp1.status_code == 200
+    assert set(resp1.data["options"].keys()) == {"Good", "Better", "Best"}
+
+    resp2 = client.post(
+        "/api/quotes/estimate",
+        data,
+        format="json",
+        HTTP_X_TENANT="t1",
+        HTTP_IDEMPOTENCY_KEY=key,
+    )
+    assert resp2.status_code == 200
+    assert resp2.json() == resp1.json()

--- a/tests/quote/test_api_quotes_crud.py
+++ b/tests/quote/test_api_quotes_crud.py
@@ -1,0 +1,84 @@
+import hashlib
+import hmac
+import json
+
+import pytest
+from django.conf import settings
+from rest_framework.test import APIClient
+
+from tenants.models import Tenant
+
+
+@pytest.mark.django_db
+def test_quote_crud_and_acceptance():
+    Tenant.objects.create(name="t1", domain="t1")
+    Tenant.objects.create(name="t2", domain="t2")
+    client = APIClient()
+    quote_body = {
+        "tenant": "t1",
+        "number": "Q-1",
+        "currency": "EUR",
+        "vat_rate": "0.25",
+        "is_vat_registered": True,
+        "risk_band": "Y",
+        "contingency_pct": "5",
+        "margin_target_pct": "10",
+        "items": [
+            {
+                "type": "fabrication",
+                "uom_base": "m2",
+                "qty_base": 10.0,
+                "area_m2": 10.0,
+                "weight_kg": 20.0,
+                "conditions": {"mode": "booth"},
+            }
+        ],
+        "options": ["Good", "Better", "Best"],
+    }
+    create_resp = client.post(
+        "/api/quotes",
+        quote_body,
+        format="json",
+        HTTP_X_TENANT="t1",
+    )
+    assert create_resp.status_code == 201
+    quote_id = create_resp.data["id"]
+
+    # isolation: other tenant can't read
+    not_found = client.get(f"/api/quotes/{quote_id}", HTTP_X_TENANT="t2")
+    assert not_found.status_code == 404
+
+    get_resp = client.get(f"/api/quotes/{quote_id}", HTTP_X_TENANT="t1")
+    assert get_resp.status_code == 200
+    snapshot = get_resp.data["snapshot"]
+
+    send_resp = client.post(f"/api/quotes/{quote_id}/send", {}, HTTP_X_TENANT="t1")
+    assert send_resp.status_code == 200
+    assert send_resp.data["status"] == "sent"
+
+    payload = json.dumps(snapshot, sort_keys=True)
+    expected_hash = hmac.new(
+        settings.SECRET_KEY.encode(), payload.encode(), hashlib.sha256
+    ).hexdigest()
+    key = "accept1"
+    accept_resp = client.post(
+        f"/api/quotes/{quote_id}/accept",
+        {"acceptance_hash": expected_hash},
+        format="json",
+        HTTP_X_TENANT="t1",
+        HTTP_IDEMPOTENCY_KEY=key,
+    )
+    assert accept_resp.status_code == 200
+    assert accept_resp.data["status"] == "accepted"
+    assert accept_resp.data["accepted_at"] is not None
+
+    # idempotent
+    accept_resp2 = client.post(
+        f"/api/quotes/{quote_id}/accept",
+        {"acceptance_hash": expected_hash},
+        format="json",
+        HTTP_X_TENANT="t1",
+        HTTP_IDEMPOTENCY_KEY=key,
+    )
+    assert accept_resp2.status_code == 200
+    assert accept_resp2.json() == accept_resp.json()

--- a/tests/quote/test_estimator_examples.py
+++ b/tests/quote/test_estimator_examples.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+
+
+def make_quote():
+    return QuoteInput(
+        tenant="t1",
+        currency="EUR",
+        vat_rate=Decimal("0.25"),
+        is_vat_registered=True,
+        risk_band="Y",
+        contingency_pct=Decimal("5"),
+        margin_target_pct=Decimal("10"),
+        items=[
+            ItemInput(
+                type="fabrication",
+                uom_base="m2",
+                qty_base=50.0,
+                area_m2=50.0,
+                weight_kg=100.0,
+                conditions={"mode": "booth"},
+            )
+        ],
+        options=["Good", "Better", "Best"],
+    )
+
+
+def test_example_totals_match_expected():
+    breakdowns = estimate(make_quote())
+    assert breakdowns["Good"].net_total == Decimal("558.25")
+    assert breakdowns["Better"].net_total == Decimal("902.83")
+    assert breakdowns["Best"].net_total == Decimal("1279.74")
+    # ensure order is preserved
+    assert (
+        breakdowns["Good"].net_total < breakdowns["Better"].net_total < breakdowns["Best"].net_total
+    )

--- a/tests/quote/test_estimator_properties.py
+++ b/tests/quote/test_estimator_properties.py
@@ -1,0 +1,89 @@
+from decimal import Decimal
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+from prodaja.services.estimator.pricing import money
+
+
+def make_quote(area, mode="booth", vat_rate=Decimal("0.25")):
+    weight = area * 2
+    return QuoteInput(
+        tenant="t1",
+        currency="EUR",
+        vat_rate=vat_rate,
+        is_vat_registered=True,
+        risk_band="Y",
+        contingency_pct=Decimal("5"),
+        margin_target_pct=Decimal("10"),
+        items=[
+            ItemInput(
+                type="fabrication",
+                uom_base="m2",
+                qty_base=area,
+                area_m2=area,
+                weight_kg=weight,
+                conditions={"mode": mode},
+            )
+        ],
+        options=["Good", "Better", "Best"],
+    )
+
+
+@given(st.floats(min_value=0.1, max_value=100))
+def test_non_negative(area):
+    res = estimate(make_quote(area))["Good"]
+    for val in res.components.values():
+        assert val >= 0
+    assert res.net_total >= 0
+    assert res.vat_total >= 0
+    assert res.gross_total >= 0
+
+
+@given(st.floats(min_value=1, max_value=50), st.floats(min_value=1, max_value=50))
+def test_monotonic(area1, area2):
+    assume(area2 > area1)
+    n1 = estimate(make_quote(area1))["Good"].net_total
+    n2 = estimate(make_quote(area2))["Good"].net_total
+    assert n2 >= n1
+
+
+@given(st.floats(min_value=1, max_value=40), st.floats(min_value=1, max_value=40))
+def test_additivity(a1, a2):
+    res1 = estimate(make_quote(a1))["Good"].net_total
+    res2 = estimate(make_quote(a2))["Good"].net_total
+    combined = estimate(make_quote(a1 + a2))["Good"].net_total
+    assert abs((res1 + res2) - combined) <= Decimal("1.00")
+
+
+@given(st.floats(min_value=1, max_value=100))
+def test_dft_increases_paint(area):
+    res = estimate(make_quote(area))
+    assert res["Better"].components["paint"] >= res["Good"].components["paint"]
+    assert res["Best"].components["paint"] >= res["Better"].components["paint"]
+
+
+@given(st.floats(min_value=1, max_value=100))
+def test_conditions_field_more_expensive(area):
+    booth = estimate(make_quote(area, mode="booth"))["Good"].components["labor"]
+    field = estimate(make_quote(area, mode="field"))["Good"].components["labor"]
+    assert field >= booth
+
+
+@given(st.floats(min_value=1, max_value=100), st.floats(min_value=0.05, max_value=0.30))
+def test_vat_consistency(area, vat):
+    vat_rate = Decimal(str(vat))
+    res = estimate(make_quote(area, vat_rate=vat_rate))["Good"]
+    expected_vat = money(res.net_total * vat_rate)
+    assert res.vat_total == expected_vat
+    assert res.gross_total == res.net_total + res.vat_total
+
+
+@given(st.floats(min_value=1, max_value=100))
+def test_rounding_identity(area):
+    res = estimate(make_quote(area))["Good"]
+    comp_sum = sum(res.components.values())
+    assert comp_sum + res.contingency + res.margin == res.net_total
+    assert res.net_total + res.vat_total == res.gross_total

--- a/tests/quote/test_estimator_smoke.py
+++ b/tests/quote/test_estimator_smoke.py
@@ -1,0 +1,43 @@
+from decimal import Decimal
+
+from prodaja.services.estimator.dto import ItemInput, QuoteInput
+from prodaja.services.estimator.engine import estimate
+
+
+def make_quote(area=50.0, weight=100.0, mode="booth"):
+    return QuoteInput(
+        tenant="t1",
+        currency="EUR",
+        vat_rate=Decimal("0.25"),
+        is_vat_registered=True,
+        risk_band="Y",
+        contingency_pct=Decimal("5"),
+        margin_target_pct=Decimal("10"),
+        items=[
+            ItemInput(
+                type="fabrication",
+                uom_base="m2",
+                qty_base=area,
+                area_m2=area,
+                weight_kg=weight,
+                conditions={"mode": mode},
+            )
+        ],
+        options=["Good", "Better", "Best"],
+    )
+
+
+def test_smoke_three_options_positive_totals():
+    quote = make_quote()
+    breakdowns = estimate(quote)
+    assert set(breakdowns.keys()) == {"Good", "Better", "Best"}
+    for bd in breakdowns.values():
+        assert bd.net_total > 0
+        assert bd.vat_total > 0
+        assert bd.gross_total > 0
+
+
+def test_monotonic_increase_with_area():
+    small = estimate(make_quote(area=10.0))["Good"].net_total
+    large = estimate(make_quote(area=20.0))["Good"].net_total
+    assert large > small

--- a/tests/quote/test_quote_pdf.py
+++ b/tests/quote/test_quote_pdf.py
@@ -1,0 +1,47 @@
+import pytest
+
+from prodaja.models.quote import EstimSnapshot, Quote, QuoteOption
+from prodaja.services.quote_pdf import compute_snapshot_hash, render_client_pdf
+from tenants.models import Tenant
+
+
+@pytest.mark.django_db
+def test_pdf_render_and_hash_changes():
+    tenant = Tenant.objects.create(name="t1", domain="t1")
+    quote = Quote.objects.create(
+        tenant=tenant,
+        number="Q1",
+        currency="EUR",
+        vat_rate="0.25",
+        is_vat_registered=True,
+        customer_name="ACME",
+        risk_band="Y",
+        contingency_pct="5",
+        margin_target_pct="10",
+    )
+    option = QuoteOption.objects.create(tenant=tenant, quote=quote, name="Good")
+    snapshot = EstimSnapshot.objects.create(
+        tenant=tenant,
+        quote=quote,
+        option=option,
+        norms_version="v1",
+        price_list_version="p1",
+        rounding_policy="item",
+        input_data={},
+        breakdown={
+            "components": {"material": 100},
+            "net_total": 100,
+            "vat_total": 25,
+            "gross_total": 125,
+        },
+        version="1",
+    )
+
+    pdf = render_client_pdf(quote.id, option.name)
+    assert len(pdf) > 0
+
+    hash1 = compute_snapshot_hash(snapshot)
+    snapshot.rounding_policy = "total"
+    snapshot.save()
+    hash2 = compute_snapshot_hash(snapshot)
+    assert hash1 != hash2


### PR DESCRIPTION
## Summary
- define quote-related models and migrations
- expose estimator-powered quote API with idempotency and acceptance hash verification
- add tests for estimate and quote CRUD endpoints

## Testing
- `pre-commit run --files prodaja/models/quote.py prodaja/models/__init__.py prodaja/models.py prodaja/migrations/0014_quote_models.py prodaja/api.py prodaja/api_urls.py erp_system/urls.py erp_system/settings/base.py tests/quote/test_api_estimate.py tests/quote/test_api_quotes_crud.py`
- `pytest tests/quote -q`


------
https://chatgpt.com/codex/tasks/task_e_68a716ed7c288322b3921fce98e06d95