### PR TITLE
feat(prodaja): add quote pdf renderer with snapshot hash

### DIFF
--- a/prodaja/pdf/render.py
+++ b/prodaja/pdf/render.py
@@ -8,11 +8,11 @@ from weasyprint import HTML
 from prodaja.models.quote import EstimSnapshot, Quote, QuoteOption
 
 
-def _get_snapshot(quote: Quote, option: QuoteOption) -> EstimSnapshot:
+def _get_snapshot(quote: Quote, option: QuoteOption) -> EstimSnapshot | None:
     return EstimSnapshot.objects.filter(quote=quote, option=option).order_by("-created_at").first()
 
 
-def compute_snapshot_hash(snapshot: EstimSnapshot) -> str:
+def compute_snapshot_sha256(snapshot: EstimSnapshot) -> str:
     payload = {
         "rounding_policy": snapshot.rounding_policy,
         "norms_version": snapshot.norms_version,
@@ -23,26 +23,31 @@ def compute_snapshot_hash(snapshot: EstimSnapshot) -> str:
     return hashlib.sha256(serialized.encode()).hexdigest()
 
 
-def _render(template: str, quote_id: int, option_name: str) -> bytes:
+def render_pdf(quote_id: int, option_name: str, variant: str) -> bytes:
+    if variant not in {"client", "internal"}:
+        raise ValueError("Unknown variant")
+
     quote = Quote.objects.get(id=quote_id)
     option = quote.options.get(name=option_name)
     snapshot = _get_snapshot(quote, option)
     if not snapshot:
         raise ValueError("Snapshot not found")
-    snapshot_hash = compute_snapshot_hash(snapshot)
+
+    snapshot_sha256 = compute_snapshot_sha256(snapshot)
     context: dict[str, Any] = {
         "quote": quote,
         "option": option,
         "breakdown": snapshot.breakdown,
-        "snapshot_hash": snapshot_hash,
+        "snapshot_sha256": snapshot_sha256,
     }
+    template = f"prodaja/pdf/{variant}.html"
     html = render_to_string(template, context)
     return HTML(string=html).write_pdf()
 
 
 def render_client_pdf(quote_id: int, option_name: str) -> bytes:
-    return _render("quotes/client.html", quote_id, option_name)
+    return render_pdf(quote_id, option_name, "client")
 
 
 def render_internal_pdf(quote_id: int, option_name: str) -> bytes:
-    return _render("quotes/internal.html", quote_id, option_name)
+    return render_pdf(quote_id, option_name, "internal")

--- a/prodaja/templates/prodaja/pdf/client.html
+++ b/prodaja/templates/prodaja/pdf/client.html
@@ -25,6 +25,6 @@
       <tr class="totals"><td>Gross total</td><td>{{ breakdown.gross_total }}</td></tr>
     </table>
 
-    <div class="meta">Snapshot: {{ snapshot_hash }}</div>
+    <div class="meta">Snapshot: {{ snapshot_sha256 }}</div>
   </body>
 </html>

--- a/prodaja/templates/prodaja/pdf/internal.html
+++ b/prodaja/templates/prodaja/pdf/internal.html
@@ -24,6 +24,6 @@
       <tr class="totals"><td>Gross total</td><td>{{ breakdown.gross_total }}</td></tr>
     </table>
 
-    <div class="meta">Snapshot: {{ snapshot_hash }}</div>
+    <div class="meta">Snapshot: {{ snapshot_sha256 }}</div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- implement unified quote PDF renderer with client and internal variants
- include snapshot SHA256 in PDF footer
- test PDF generation and hash changes when rounding policy updates

## Testing
- `pre-commit run --files prodaja/pdf/__init__.py prodaja/pdf/render.py prodaja/templates/prodaja/pdf/client.html prodaja/templates/prodaja/pdf/internal.html tests/prodaja/test_quote_pdf.py`
- `pytest tests/prodaja/test_quote_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68abf9ee0db4832281fc9c73a79d2acd