### PR TITLE
Implement ledger engine with locking, reversal, and posting rules

### DIFF
--- a/financije/services/fiskalizacija_stub.py
+++ b/financije/services/fiskalizacija_stub.py
@@ -1,0 +1,44 @@
+import hashlib
+import json
+from dataclasses import dataclass
+
+
+AUDIT_LOG: list[dict] = []
+
+
+def _compute_zki(number: str, issued_at, net: str, operator_mark: str) -> str:
+    seed = f"{number}|{issued_at}|{net}|{operator_mark}"
+    return hashlib.sha1(seed.encode()).hexdigest()
+
+
+@dataclass
+class FiscalizationResult:
+    zki: str
+    jir: str
+    qr: str
+
+
+def fiscalize(invoice) -> FiscalizationResult:
+    """Fake fiscalization service.
+
+    Generates deterministic ZKI, simulates JIR response and records an
+    audit log with request/response hashes. Returns QR payload string that
+    can be embedded into PDFs.
+    """
+
+    payload = {
+        "number": invoice.number,
+        "issued_at": invoice.issued_at.isoformat(),
+        "net": str(invoice.net_total),
+        "operator": invoice.operator_mark,
+    }
+    req_hash = hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+    zki = _compute_zki(invoice.number, payload["issued_at"], payload["net"], invoice.operator_mark)
+    jir = hashlib.sha1((zki + "jir").encode()).hexdigest()
+    qr = json.dumps({"n": invoice.number, "zki": zki, "jir": jir})
+    resp_hash = hashlib.sha256(json.dumps({"jir": jir, "zki": zki}, sort_keys=True).encode()).hexdigest()
+    AUDIT_LOG.append({"request_hash": req_hash, "response_hash": resp_hash})
+    return FiscalizationResult(zki=zki, jir=jir, qr=qr)
+
+
+__all__ = ["fiscalize", "FiscalizationResult", "AUDIT_LOG"]

--- a/financije/services/posting_rules.py
+++ b/financije/services/posting_rules.py
@@ -1,0 +1,49 @@
+
+"""Helper functions for explicit ledger postings.
+
+These helpers replace the old signal based implementation by explicitly
+calling :func:`financije.ledger.post_transaction` with predefined event
+names.
+"""
+from decimal import Decimal
+
+from financije.ledger import post_transaction
+
+
+def sale_invoice_posted(*, tenant, net: Decimal, vat: Decimal = Decimal("0.00"), idempotency_key: str | None = None):
+    payload = {"net": net, "vat": vat, "description": "sale invoice"}
+    return post_transaction(tenant=tenant, event="SALE_INVOICE_POSTED", payload=payload, idempotency_key=idempotency_key)
+
+
+def purchase_invoice_posted(*, tenant, net: Decimal, vat: Decimal = Decimal("0.00"), idempotency_key: str | None = None):
+    payload = {"net": net, "vat": vat, "description": "purchase invoice"}
+    return post_transaction(tenant=tenant, event="PURCHASE_INVOICE_POSTED", payload=payload, idempotency_key=idempotency_key)
+
+
+def advance_receipt(*, tenant, amount: Decimal, idempotency_key: str | None = None):
+    payload = {"amount": amount}
+    return post_transaction(tenant=tenant, event="ADVANCE_RECEIPT", payload=payload, idempotency_key=idempotency_key)
+
+
+def advance_settlement(*, tenant, amount: Decimal, idempotency_key: str | None = None):
+    payload = {"amount": amount}
+    return post_transaction(tenant=tenant, event="ADVANCE_SETTLEMENT", payload=payload, idempotency_key=idempotency_key)
+
+
+def bank_customer_payment(*, tenant, amount: Decimal, idempotency_key: str | None = None):
+    payload = {"amount": amount}
+    return post_transaction(tenant=tenant, event="BANK_CUSTOMER_PAYMENT", payload=payload, idempotency_key=idempotency_key)
+
+
+def bank_supplier_payment(*, tenant, amount: Decimal, idempotency_key: str | None = None):
+    payload = {"amount": amount}
+    return post_transaction(tenant=tenant, event="BANK_SUPPLIER_PAYMENT", payload=payload, idempotency_key=idempotency_key)
+
+__all__ = [
+    "sale_invoice_posted",
+    "purchase_invoice_posted",
+    "advance_receipt",
+    "advance_settlement",
+    "bank_customer_payment",
+    "bank_supplier_payment",
+]

--- a/prodaja/migrations/0016_invoice_model.py
+++ b/prodaja/migrations/0016_invoice_model.py
@@ -1,0 +1,68 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+from decimal import Decimal
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tenants", "0005_tenant_vat_fiscal_and_settings_accounts"),
+        ("prodaja", "0015_work_order_models"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Invoice",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID"),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="Created at")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Updated at")),
+                ("is_active", models.BooleanField(default=True, verbose_name="Active")),
+                (
+                    "number",
+                    models.CharField(
+                        max_length=20,
+                        help_text="Formatted as NNN-OO-UU",
+                    ),
+                ),
+                ("issued_at", models.DateTimeField()),
+                ("operator_mark", models.CharField(max_length=16)),
+                (
+                    "net_amount",
+                    models.DecimalField(decimal_places=2, default=Decimal("0.00"), max_digits=12),
+                ),
+                (
+                    "vat_amount",
+                    models.DecimalField(decimal_places=2, default=Decimal("0.00"), max_digits=12),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="invoice_created",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="invoice_updated",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "tenant",
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="tenants.tenant"),
+                ),
+            ],
+            options={"ordering": ["-created_at"], "unique_together": {("tenant", "number")}},
+        ),
+    ]

--- a/prodaja/models.py
+++ b/prodaja/models.py
@@ -7,3 +7,4 @@ Keep this file minimal to avoid duplicate model definitions and migration noise.
 from .models.main import *  # noqa: F401,F403
 from .models.quote import *  # noqa: F401,F403
 from .models.work_order import *  # noqa: F401,F403
+from .models.invoice import *  # noqa: F401,F403

--- a/prodaja/models/__init__.py
+++ b/prodaja/models/__init__.py
@@ -1,3 +1,4 @@
 from .main import *  # noqa: F401,F403 re-export all defined model classes
 from .quote import *  # noqa: F401,F403
 from .work_order import *  # noqa: F401,F403
+from .invoice import *  # noqa: F401,F403

--- a/prodaja/models/invoice.py
+++ b/prodaja/models/invoice.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.core.validators import RegexValidator
+from django.db import models
+from django.utils import timezone
+
+from common.models import BaseModel
+from tenants.models import Tenant
+
+
+class Invoice(BaseModel):
+    """Minimal sales invoice model used for posting tests."""
+
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
+    number = models.CharField(
+        max_length=20,
+        validators=[RegexValidator(r"^\d{3}-\d{2}-\d{2}$")],
+        help_text="Formatted as NNN-OO-UU",
+    )
+    issued_at = models.DateTimeField(default=timezone.now)
+    operator_mark = models.CharField(max_length=16)
+    net_amount = models.DecimalField(max_digits=12, decimal_places=2, default=Decimal("0.00"))
+    vat_amount = models.DecimalField(max_digits=12, decimal_places=2, default=Decimal("0.00"))
+
+    class Meta:
+        ordering = ["-created_at"]
+        unique_together = ("tenant", "number")
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"Invoice {self.number}"
+
+    @property
+    def net_total(self) -> Decimal:
+        return self.net_amount
+
+    def post(self):
+        from financije.services.posting_rules import sale_invoice_posted
+
+        return sale_invoice_posted(
+            tenant=self.tenant,
+            net=self.net_amount,
+            vat=self.vat_amount,
+            idempotency_key=f"invoice:{self.pk}",
+        )

--- a/prodaja/pdf/invoice.py
+++ b/prodaja/pdf/invoice.py
@@ -1,0 +1,9 @@
+from django.template.loader import render_to_string
+from weasyprint import HTML
+
+
+def render_invoice_pdf(invoice, qr: str) -> bytes:
+    """Render minimal invoice PDF embedding QR payload."""
+
+    html = render_to_string("prodaja/pdf/invoice.html", {"invoice": invoice, "qr": qr})
+    return HTML(string=html).write_pdf()

--- a/prodaja/templates/prodaja/pdf/invoice.html
+++ b/prodaja/templates/prodaja/pdf/invoice.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Invoice {{ invoice.number }}</h1>
+    <p>Issued: {{ invoice.issued_at }}</p>
+    <p>QR: {{ qr }}</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Ensure Account numbers are unique per tenant
- Add immutable ledger posting with idempotency, locking, and reversal support
- Provide helper posting rule functions for common financial events
- Introduce minimal sales invoice model that posts to ledger
- Stub fiscalization service producing ZKI/JIR with QR data for PDF output

## Testing
- `pytest tests/ledger/test_k1_postings.py -q`
- `pytest tests/test_ledger_core.py -q`
- `pytest tests/prodaja/test_invoice_posting.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68abfdef9a708322a8b588c20c7e1622