### PR TITLE
Add database backup/restore targets and demo bootstrap script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,9 @@
-dev:
-	docker-compose up --build
+dev: ; docker-compose up --build
+
+# Create a PostgreSQL backup using pg_dump. Requires DATABASE_URL
+# environment variable in libpq format, e.g. postgres://user:pass@host:5432/db
+backup: ; @test -n "$$DATABASE_URL" || (echo "DATABASE_URL is not set" && exit 1); pg_dump $$DATABASE_URL > backup.sql
+
+# Restore a PostgreSQL backup previously created with make backup.
+# Will overwrite existing data in the target database.
+restore: ; @test -n "$$DATABASE_URL" || (echo "DATABASE_URL is not set" && exit 1); psql $$DATABASE_URL < backup.sql

--- a/scripts/bootstrap_demo.py
+++ b/scripts/bootstrap_demo.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Bootstrap a demo environment with sample data.
+
+This helper runs database migrations, loads a minimal fixture
+and creates a default superuser. It is intended for onboarding
+new developers so they can quickly have a working demo instance.
+
+Environment variables:
+    DATABASE_URL  - connection string for Postgres (libpq format)
+    REDIS_URL     - Redis connection (default: redis://localhost:6379/0)
+    DJANGO_SETTINGS_MODULE - Django settings module (default: erp_system.settings.base)
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def run(cmd: list[str]) -> None:
+    """Run a subprocess and stream output."""
+    process = subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    env = os.environ.copy()
+    env.setdefault("DJANGO_SETTINGS_MODULE", "erp_system.settings.base")
+    env.setdefault("REDIS_URL", "redis://localhost:6379/0")
+    if "DATABASE_URL" not in env:
+        print("DATABASE_URL is not set", file=sys.stderr)
+        return 1
+
+    commands = [
+        ["python", "manage.py", "migrate", "--noinput"],
+    ]
+    fixture = "erp_system/fixtures/minimal.json"
+    if os.path.exists(fixture):
+        commands.append(["python", "manage.py", "loaddata", fixture])
+    commands.append(
+        [
+            "python",
+            "manage.py",
+            "createsuperuser",
+            "--noinput",
+            "--username",
+            "admin",
+            "--email",
+            "admin@example.com",
+        ]
+    )
+
+    for cmd in commands:
+        print("$", " ".join(cmd))
+        try:
+            subprocess.run(cmd, env=env, check=True)
+        except subprocess.CalledProcessError as exc:
+            print(f"Command {cmd} failed with {exc.returncode}", file=sys.stderr)
+            return exc.returncode
+    print("Demo bootstrap complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `backup` and `restore` Makefile targets for PostgreSQL using DATABASE_URL
- provide `scripts/bootstrap_demo.py` to seed demo data and create a default admin

## Testing
- `make backup` *(fails: DATABASE_URL is not set; pg_dump: not found)*
- `python scripts/bootstrap_demo.py` *(fails: DATABASE_URL is not set)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ac39a4bc048322a2232255abcb00f4